### PR TITLE
Change attribute scope.

### DIFF
--- a/ledger/src/sigverify_shreds.rs
+++ b/ledger/src/sigverify_shreds.rs
@@ -246,7 +246,7 @@ pub fn verify_shreds_gpu(
     out.set_pinnable();
     elems.push(
         perf_libs::Elems {
-            #![allow(clippy::cast_ptr_alignment)]
+            #[allow(clippy::cast_ptr_alignment)]
             elems: pubkeys.as_ptr() as *const solana_sdk::packet::Packet,
             num: num_packets as u32,
         },
@@ -385,7 +385,7 @@ pub fn sign_shreds_gpu(
     signatures_out.resize(total_sigs * sig_size, 0);
     elems.push(
         perf_libs::Elems {
-            #![allow(clippy::cast_ptr_alignment)]
+            #[allow(clippy::cast_ptr_alignment)]
             elems: pinned_keypair.as_ptr() as *const solana_sdk::packet::Packet,
             num: num_keypair_packets as u32,
         },


### PR DESCRIPTION
#### Problem
Does not compile on Rust 1.54.0

#### Summary of Changes
The attribute 'allow  cast pointer alignment' is really an inner attribute here, not an outer one, so the syntax has to be updated accordingly.
