### PR TITLE
Dynamic trait needs to be flagged accordingly.

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1231,7 +1231,7 @@ fn do_process_deploy(
         CliError::DynamicProgramError(format!("Unable to read program file: {}", err))
     })?;
 
-    Executable::<BPFError, ThisInstructionMeter>::from_elf(
+    <dyn Executable::<BPFError, ThisInstructionMeter>>::from_elf(
         &program_data,
         Some(|x| bpf_verifier::check(x, false)),
         Config::default(),

--- a/programs/bpf/benches/bpf_loader.rs
+++ b/programs/bpf/benches/bpf_loader.rs
@@ -76,7 +76,7 @@ fn bench_program_create_executable(bencher: &mut Bencher) {
 
     bencher.iter(|| {
         let _ =
-            Executable::<BPFError, ThisInstructionMeter>::from_elf(&elf, None, Config::default())
+            <dyn Executable::<BPFError, ThisInstructionMeter>>::from_elf(&elf, None, Config::default())
                 .unwrap();
     });
 }
@@ -95,7 +95,7 @@ fn bench_program_alu(bencher: &mut Bencher) {
 
     let elf = load_elf("bench_alu").unwrap();
     let mut executable =
-        Executable::<BPFError, ThisInstructionMeter>::from_elf(&elf, None, Config::default())
+        <dyn Executable::<BPFError, ThisInstructionMeter>>::from_elf(&elf, None, Config::default())
             .unwrap();
     executable.set_syscall_registry(register_syscalls(&mut invoke_context).unwrap());
     executable.jit_compile().unwrap();
@@ -221,7 +221,7 @@ fn bench_instruction_count_tuner(_bencher: &mut Bencher) {
 
     let elf = load_elf("tuner").unwrap();
     let mut executable =
-        Executable::<BPFError, ThisInstructionMeter>::from_elf(&elf, None, Config::default())
+        <dyn Executable::<BPFError, ThisInstructionMeter>>::from_elf(&elf, None, Config::default())
             .unwrap();
     executable.set_syscall_registry(register_syscalls(&mut invoke_context).unwrap());
     let compute_meter = invoke_context.get_compute_meter();

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -92,7 +92,7 @@ fn run_program(
         enable_instruction_meter: true,
         enable_instruction_tracing: true,
     };
-    let mut executable = Executable::from_elf(&data, None, config).unwrap();
+    let mut executable = <dyn Executable>::from_elf(&data, None, config).unwrap();
     executable.set_syscall_registry(register_syscalls(&mut invoke_context).unwrap());
     executable.jit_compile().unwrap();
 

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -98,7 +98,7 @@ pub fn create_and_cache_executor(
     invoke_context: &mut dyn InvokeContext,
 ) -> Result<Arc<BPFExecutor>, InstructionError> {
     let bpf_compute_budget = invoke_context.get_bpf_compute_budget();
-    let mut executable = Executable::<BPFError, ThisInstructionMeter>::from_elf(
+    let mut executable = <dyn Executable::<BPFError, ThisInstructionMeter>>::from_elf(
         &program.try_account_ref()?.data,
         None,
         Config {
@@ -370,7 +370,7 @@ mod tests {
         ];
         let input = &mut [0x00];
 
-        let executable = Executable::<BPFError, TestInstructionMeter>::from_text_bytes(
+        let executable = <dyn Executable::<BPFError, TestInstructionMeter>>::from_text_bytes(
             program,
             None,
             Config::default(),


### PR DESCRIPTION
#### Problem
Fix a compiler warning on rust 1.54.0

#### Summary of Changes
Opaque types that are resolved dynamically should be flagged as such.
https://doc.rust-lang.org/std/keyword.dyn.html

Fixes #
